### PR TITLE
main: add IO500_MINWRITE constant

### DIFF
--- a/include/io500-phase.h
+++ b/include/io500-phase.h
@@ -32,6 +32,7 @@ typedef struct{
   io500_phase_score_group group;
 } u_phase_t;
 
+#define IO500_MINWRITE 300
 #define IO500_PHASES (2 + 1 + 2*3 + 1 + 4 + 5)
 
 extern u_phase_t p_opt;

--- a/src/main.c
+++ b/src/main.c
@@ -269,7 +269,10 @@ int main(int argc, char ** argv){
 
         char score_str[40];
         sprintf(score_str, "%f", score);
-        dupprintf("[RESULT] %20s %15s %s : time %.3f seconds\n", phase->name, score_str, phase->name[0] == 'i' ? "GiB/s " : "kIOPS", runtime);
+        dupprintf("[RESULT%s] %20s %15s %s : time %.3f seconds\n",
+		  phase->type == IO500_PHASE_WRITE && runtime < IO500_MINWRITE ?
+			"-invalid" : "",
+		  phase->name, score_str, phase->name[0] == 'i' ? "GiB/s " : "kIOPS", runtime);
       }
       u_hash_update_key_val_dbl(& score_hash, phase->name, score);
     }
@@ -330,7 +333,7 @@ int main(int argc, char ** argv){
     PRINT_PAIR("hash", "%X\n", (int) score_hash);
 
     dupprintf("[SCORE%s] Bandwidth %f GB/s : IOPS %f kiops : TOTAL %f\n",
-      opt.is_valid_run ? "" : " INVALID",
+      opt.is_valid_run ? "" : "-invalid",
       scores[IO500_SCORE_BW], scores[IO500_SCORE_MD], overall_score);
   }
 

--- a/src/phase_dbg.c
+++ b/src/phase_dbg.c
@@ -1,13 +1,15 @@
 #include <io500-phase.h>
 
+#define STRINGIFY(foo)  #foo
+
 static ini_option_t option[] = {
-  {"stonewall-time", "The stonewall timer, set to a smaller value for testing", 0, INI_UINT, "300", & opt.stonewall},
+  {"stonewall-time", "The stonewall timer, set to a smaller value for testing", 0, INI_UINT, STRINGIFY(IO500_MINWRITE), & opt.stonewall},
   {NULL} };
 
 
 static void validate(void){
-  if(opt.stonewall != 300 && opt.rank == 0){
-    INVALID("stonewall-time != 300\n");
+  if(opt.stonewall != IO500_MINWRITE && opt.rank == 0){
+    INVALID("stonewall-time != %us\n", IO500_MINWRITE);
   }
 }
 


### PR DESCRIPTION
Add a constant for the 300s minimum runtime, rather than
hard-coding it in several places in the code.  It will
eventually also needed for Student Cluster Competition.

Use it to print "-invalid" markers for any subtests that
didn't run for a long enough time.  That should never
happen, but it makes the bad result(s) easier to see.

Signed-off-by: Andreas Dilger <adilger@dilger.ca>