### PR TITLE
For isc20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
 # ISC-20
+  * Combined script/C-app runs via io500.sh to validate continuity of results
   * Support hashing of configuration option and optained result to allow verification of results.
   * Pfind provides additional options for parallelizing large directories (see pfind directory) and diagnostics output.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Then you can compile the io500 application running make.
 
 ## Usage
 
-The benchmark requires a INI file containing the options.
-The INI file is structured in sections depending on the phase.
+The benchmark requires a .ini file containing the options.
+The .ini file is structured in sections depending on the phase.
 
 Detailed help for the available options is provided when running:
 
@@ -23,13 +23,34 @@ Detailed help for the available options is provided when running:
 
 The benchmark output the commands it would run (equivalence of command line invocations of ior/mdtest). Use --dry-run to not invoke any command.
 
-Two INI files are provided, the config-minimal.ini and the config-some.ini.
+Three .ini files are provided, the config-minimal.ini and the config-some.ini.
   - The minimal example contains the only mandatory parameter, the data directory. It also sets the stonewalling to 1 for testing.
   - The config-some illustrates the setting of various options. For more details, run ./io500 -h.
+  - The config-all shows all available configuration options and their default values.  This is generated from ./io500 --list.
 
 To see the currently active options, run:
 
-    $ ./io500 <INI file> -h
+    $ ./io500 <file.ini> -h
+
+### IO500 Benchmark Run
+
+To run a full benchmark session, the stonewall-time must be set to 300.
+Use the io500.sh script to run both a pass with the bash-script and a
+second run with the C-app.  The results will be put into two separate
+directories and tarred up for submission.  The io500.sh script also
+uses the same .ini file for most options, but at a minimum needs the
+io500_mpirun and io500_mpiargs values set for your system in the
+setup_paths() function at the start of the io500.sh script.  The
+paths to the installed IOR and mdtest binaries are also needed if
+they were installed separately.  The script must be run from within
+the Git checkout tree.
+
+    $ ./io500.sh <file.ini>
+
+It may also be desirable to update the setup_directories() function
+to create the top-level output directories for the test files.
+These are created before the test run, and may hold directory and
+file layout parameters.
 
 ### Integrity check
 
@@ -42,7 +63,7 @@ You can either use the full-featured io500 application:
     score-hash  = C97CC873
     [OK] But this is an invalid run!
 
-Or the lightweight verification tool which has less dependencies:
+Or the lightweight verification tool which has fewer dependencies:
 
     $ ./io500-verify config-test-run.ini result.txt
 

--- a/config-full.ini
+++ b/config-full.ini
@@ -3,10 +3,8 @@
 datadir = ./datafiles
 # The data directory is suffixed by a timestamp. Useful for running several IO500 tests concurrently.
 timestamp-datadir = TRUE
-
 # The result directory.
 resultdir = ./results
-
 # The result directory is suffixed by a timestamp. Useful for running several IO500 tests concurrently.
 timestamp-resultdir = TRUE
 # The API to create/delete the datadir
@@ -19,8 +17,8 @@ drop-caches-cmd = sudo -n bash -c "echo 3 > /proc/sys/vm/drop_caches"
 verbosity = 1
 
 [debug]
-# The stonewall timer, must be at least 300s for a valid test run
-stonewall-time = 300 # 300s for full run
+# Stonewall timer must be 300 for a valid result, can be smaller for testing
+stonewall-time = 300
 
 [ior-easy]
 # The API to be used
@@ -30,13 +28,25 @@ posix.odirect =
 # Transfer size
 transferSize = 2m
 # Block size; must be a multiple of transferSize
-blockSize = 2m # 1024000m
+blockSize = 9920000m
 # Filename for MPI hint file
 hintsFileName = 
 # Create one file per process
 filePerProc = TRUE
 # Use unique directory per file per process
 uniqueDir = FALSE
+# Disable running of this phase
+noRun = 
+# The verbosity level
+verbosity = 
+
+[ior-easy-write]
+# The API to be used
+API = 
+# Use ODirect
+posix.odirect = 
+# Filename for hints file
+hintsFileName = 
 
 [mdtest-easy]
 # The API to be used
@@ -45,14 +55,64 @@ API = POSIX
 posix.odirect = 
 # Files per proc
 n = 1000000
+# Disable running of this phase
+noRun = 
+
+[mdtest-easy-write]
+# The API to be used
+API = 
+# Use ODirect
+posix.odirect = 
+# Disable running of this phase
+noRun =
 
 [ior-hard]
+# The API to be used
+API = POSIX
+# Use ODirect
+posix.odirect = 
 # Filename for hints file
 hintsFileName = 
 # Number of segments
 segmentCount = 10000000
+# Disable running of this phase
+noRun =
+# The verbosity level
+verbosity = 
+
+[ior-hard-write]
+# The API to be used
+API = 
+# Use ODirect
+posix.odirect = 
+# Filename for hints file
+hintsFileName = 
+
+[mdtest-hard]
+# The API to be used
+API = POSIX
+# Use ODirect
+posix.odirect = 
+# Files per proc
+n = 1000000
+# Disable running of this phase
+noRun =
+
+[mdtest-hard-write]
+# The API to be used
+API = 
+# Use ODirect
+posix.odirect = 
+# Disable running of this phase
+noRun =
 
 [find]
+# Set to an external script to perform the find phase
+external-script = 
+# Extra arguments for external scripts
+external-extra-args = 
+# Startup arguments for external scripts
+external-mpi-args = 
 # Set the number of processes for pfind
 nproc = 
 # Pfind queue length
@@ -60,4 +120,4 @@ pfind-queue-length = 10000
 # Pfind Steal from next
 pfind-steal-next = FALSE
 # Parallelize the readdir by using hashing. Your system must support this!
-pfind-parallelize-single-dir-access-using-hashing = TRUE
+pfind-parallelize-single-dir-access-using-hashing = FALSE

--- a/prepare.sh
+++ b/prepare.sh
@@ -7,9 +7,9 @@ echo It will also attempt to build the benchmarks
 echo It will output OK at the end if builds succeed
 echo
 
-IOR_HASH=
-IO500_HASH=
-MDREAL_HASH=
+IOR_HASH=io500-isc20
+IO500_HASH=io500-isc20
+MDREAL_HASH=io500-isc20
 
 INSTALL_DIR=$PWD
 BIN=$INSTALL_DIR/bin

--- a/src/phase_dbg.c
+++ b/src/phase_dbg.c
@@ -1,9 +1,10 @@
 #include <io500-phase.h>
 
-#define STRINGIFY(foo)  #foo
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
 
 static ini_option_t option[] = {
-  {"stonewall-time", "The stonewall timer, set to a smaller value for testing", 0, INI_UINT, STRINGIFY(IO500_MINWRITE), & opt.stonewall},
+  {"stonewall-time", "Stonewall timer must be "TOSTRING(IO500_MINWRITE)" for a valid result, can be smaller for testing", 0, INI_UINT, TOSTRING(IO500_MINWRITE), & opt.stonewall},
   {NULL} };
 
 


### PR DESCRIPTION
This updates the io500.sh script for ISC20 (README.md, CHANGELOG.md) as well as the prepare.sh script to reference (currently non-existent) `io500-isc20` tags in the IOR, io-500-dev, and io500-app repos.

Once this patch is tested locally and landed those tags should be created.  It would be possible to create the `io500-isc20` tag on the IOR repo now, since there aren't any pending ISC20 changes for it.

There will be a separate push to the io-500-dev repo in a for-isc20 branch that also updates the README.md and CHANGELOG.md files there, and makes it clear that repo is deprecated by printing an error and refusing to run unless it is done as part of the io500.sh script here.

That patch should be landed when this one is landed, and both can be tagged.  I'm not sure if I can push tags myself, so Julian might need to do that.