### PR TITLE
prepare: allow prepare.sh to be run multiple times

### DIFF
--- a/io500.sh
+++ b/io500.sh
@@ -143,12 +143,14 @@ function main {
   setup_mdreal   # optional
   run_benchmarks
 
-  create_tarball
-
-  if [[ ! -s "system-information.txt" ]]; then
-    echo "Warning: please create a system information, e.g. (system-information.txt) by copying"
-    echo "the information from https://vi4io.org/io500-info-creator/"
+  if [[ -s "system-information.txt" ]]; then
+    echo "Warning: please create a system-information.txt description by"
+    echo "copying the information from https://vi4io.org/io500-info-creator/"
+  else
+    cp "system-information.txt" $io500_result_dir
   fi
+
+  create_tarball
 }
 
 function setup_ior_easy {

--- a/prepare.sh
+++ b/prepare.sh
@@ -88,11 +88,10 @@ function build_ior {
 }
 
 function build_io500_dev {
-  ln -s $BUILD/pfind/pfind $BIN/pfind
-  mkdir $BUILD/io500-dev/build
+  mkdir -p $BUILD/io500-dev/build
   pushd $BUILD/io500-dev/build
-  ln -s $BUILD/ior
-  ln -s $BUILD/pfind
+  ln -sf $BUILD/ior
+  ln -sf $BUILD/pfind
   popd
 }
 
@@ -100,6 +99,7 @@ function build_pfind {
   pushd $BUILD/pfind
   ./prepare.sh
   ./compile.sh
+  ln -sf $BUILD/pfind/pfind $BIN/pfind
   echo "Pfind: OK"
   echo
   popd


### PR DESCRIPTION
Allow the target directories to already exist, in case prepare.sh
is run multiple times.

Copy the system-information.txt file into the tarball if present.

Signed-off-by: Andreas Dilger <adilger@dilger.ca>