### PR TITLE
io500: avoid segfault when parsing bad .ini input

### DIFF
--- a/src/ini-parse.c
+++ b/src/ini-parse.c
@@ -211,7 +211,7 @@ int u_parse_ini(char const * data, ini_section_t ** sections, ini_call_back_f cb
       // must be the empty line
       reti = regexec(&r_empty, token, 0, NULL, 0);
       if (reti != 0) {
-          ERROR("Parsing error in section %s line %d, unexpected content: \"%s\"\n", section->name, line, token);
+          ERROR("Parsing error in section %s line %d, unexpected content: \"%s\"\n", section ? section->name : "no_section", line, token);
           return 1;
       }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -97,7 +97,8 @@ int main(int argc, char ** argv){
   }
   if (argc < 2 || strcmp(argv[1], "-l") == 0 || strcmp(argv[1], "--list") == 0){
     if (rank == 0){
-      r0printf("Supported and current values of the ini file:\n");
+      /* print this as a comment, in case it is saved into the .ini file */
+      r0printf(stderr, "# Supported and current values of the ini file:\n");
       u_ini_print_values(stdout, cfg, TRUE);
     }
     goto out;


### PR DESCRIPTION
If there is an invalid line of text at the start of the .ini file
before the first [global] section has been parsed in u_parse_ini(),
then the "section" pointer is still NULL and trying to print it in
the error message results in a segfault.  Avoid the NULL section.

Running "./io500 --list > config-new.ini" would result in the line
"Supported and current values of the ini file:" being included at
the start of the .ini file, which triggered this segfault.  Print
this line as a comment so that this works as one would expect.

Signed-off-by: Andreas Dilger <adilger@dilger.ca>