### PR TITLE
prepare: update with proper tags for ISC20

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -8,7 +8,7 @@ echo It will output OK at the end if builds succeed
 echo
 
 IOR_HASH=48eb1880
-IO500_HASH=afb0b23
+IO500_HASH=io500-isc20
 MDREAL_HASH=io500-isc20
 
 INSTALL_DIR=$PWD


### PR DESCRIPTION
Use the io500-isc20 tag (which needs to be created after this patch lands).

There is a similar PR for the io-500-app repo.