### PR TITLE
Add 'make clean' before build ior

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -82,6 +82,7 @@ function get_mdrealio {
 ###### BUILD FUNCTIONS
 function build_ior {
   pushd $BUILD/ior/src
+  $MAKE clean
   $MAKE install
   echo "IOR: OK"
   echo


### PR DESCRIPTION
Add 'make clean' before 'make' in ior otherwise building of ior/mdtest skips if old binaries are exist.